### PR TITLE
868bffvuc fix: environment casing 

### DIFF
--- a/dev.env.sample
+++ b/dev.env.sample
@@ -2,5 +2,5 @@ INTEGRATION_ID=<replace-me>
 PENNSIEVE_API_KEY=<replace-me>
 PENNSIEVE_API_SECRET=<replace-me>
 BASE_DIR=/mnt/efs
-ENVIRONMENT=LOCAL
+ENVIRONMENT=local
 REGION=us-east-1

--- a/taskRunner/config.py
+++ b/taskRunner/config.py
@@ -9,8 +9,8 @@ def getenv(key, required):
 
 class Config:
     def __init__(self):
-        self.ENVIRONMENT        = os.getenv('ENVIRONMENT', 'LOCAL').upper()
-        self.IS_LOCAL           = self.ENVIRONMENT == 'LOCAL'
+        self.ENVIRONMENT        = os.getenv('ENVIRONMENT', 'local').lower()
+        self.IS_LOCAL           = self.ENVIRONMENT == 'local'
 
         self.SUBNET_IDS         = getenv('SUBNET_IDS', not self.IS_LOCAL)
         self.CLUSTER_NAME       = getenv('CLUSTER_NAME', not self.IS_LOCAL)
@@ -18,7 +18,7 @@ class Config:
         self.BASE_DIR           = getenv('BASE_DIR', not self.IS_LOCAL)
         self.REGION             = getenv('REGION', not self.IS_LOCAL)
 
-        if self.ENVIRONMENT == 'LOCAL' or self.ENVIRONMENT == 'DEV':
+        if self.ENVIRONMENT == 'local' or self.ENVIRONMENT == 'dev':
             self.API_HOST       = 'https://api.pennsieve.net'
             self.API_HOST2      = 'https://api2.pennsieve.net'
             self.UPLOAD_BUCKET  = "pennsieve-dev-uploads-v2-use1"


### PR DESCRIPTION
## Description

Fixes a bug introduced in: https://github.com/Pennsieve/workflow-manager/pull/18

Upstream log streaming relied explicitly on the casing of the environment in the S3 key where the processor logs are copied to. The previous PR upper-cased the environment when it was historically lower case.