### PR TITLE
Add stdout and nextflow log to error log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.env
 dev.env
 workflows/processors.csv
+/.idea/


### PR DESCRIPTION
PR adds fields to what is error logged when the nextflow command fails. Adds both the stdout of the nextflow command as well as the contents of the nexflow.log file.

Current error log in this situation can look like 
```
{
    "time": "2025-02-17T17:08:23.061211102Z",
    "level": "ERROR",
    "msg": "exit status 1",
    "error": ""
}
```

which is not helpful for debugging.